### PR TITLE
sketchpane - `stampLayer` timing fix (alternative)

### DIFF
--- a/src/js/sketchpane.js
+++ b/src/js/sketchpane.js
@@ -225,7 +225,8 @@ let pointerDown = (e) => {
 }
 
 let drawBrushLoop = (timestamp)=> {
-  if (penDown) window.requestAnimationFrame(drawBrushLoop)
+  if (!penDown) return;
+  window.requestAnimationFrame(drawBrushLoop)
   //console.log(prevTimestamp-timestamp)
   prevTimestamp = timestamp
   drawBrush()


### PR DESCRIPTION
`stampLayer` was being called before the final draw resulting in
artifacts of the end of a stroke being left on `drawContext` after it’s
been cleared.

The changes herein prevent the rendering of queued points at any time
after `stampLayer`.

(Addresses issues: #44, #16)

A timing issue still exists, but to properly mitigate would require a
slightly more time-intensive refactor which would provide each stroke
an independent point array and queued rendering.