### PR TITLE
Toolbar refinements

### DIFF
--- a/src/css/toolbar.css
+++ b/src/css/toolbar.css
@@ -17,17 +17,6 @@
 #toolbar .group:not(:last-child) {
   margin-right: 10px;
 }
-/* spacer */
-#toolbar .group:not(.group_tools):not(:last-child):after {
-  content: ' ';
-  display: block;
-  position: absolute;
-  right: 0;
-  width: 1px;
-  height: 56px;
-  margin-right: -5px;
-  background-color: #444;
-}
 
 #toolbar .group:not(.group_tools) {
   border-radius: 8px;

--- a/src/css/toolbar.css
+++ b/src/css/toolbar.css
@@ -1,8 +1,27 @@
 #toolbar {
   -webkit-app-region: drag;
-  padding: 10px;
   display: flex;
   justify-content: center;
+
+  padding-top: 10px;
+  padding-bottom: 10px;
+
+  /* to avoid Mac top-left controls (close/minimize/zoom) */
+  padding-left: 60px;
+  /* to balance out for centering */
+  padding-right: 60px;
+}
+.with-script-visible #toolbar,
+.with-scenes-visible #toolbar {
+  /* if script OR scenes visible, don't bother accomodating for Mac top-left controls*/
+  padding-left: 10px;
+  padding-right: 10px;
+}
+/* when no script/scenes, prefer tightly aligning right for multi-row cols at smaller screen widths */
+@media only screen and (max-width: 1749px) {
+  #toolbar {
+    padding-right: 10px;
+  }
 }
 
 #toolbar .column {
@@ -26,14 +45,6 @@
 }
 #toolbar .group_tools {
   margin-top: -10px;
-  /* to avoid Mac top-left controls (close/minimize/zoom) */
-  margin-left: 50px;
-  margin-right: 50px;
-}
-body.with-script-visible #toolbar .group_tools,
-body.with-scenes-visible #toolbar .group_tools {
-  /* if script OR scenes visible, don't bother */
-  margin-left: 0;
 }
 
 #toolbar .button { /* */ }

--- a/src/css/toolbar.css
+++ b/src/css/toolbar.css
@@ -45,6 +45,7 @@
 }
 #toolbar .group_tools {
   margin-top: -10px;
+  margin-right: 45px;
 }
 
 #toolbar .button { /* */ }
@@ -227,7 +228,6 @@
   width: 100%;
   height: 100%;
   filter: none;
-
 }
 
 #toolbar .toolbar-colors .button:not(:last-child) {

--- a/src/css/toolbar.css
+++ b/src/css/toolbar.css
@@ -2,6 +2,7 @@
   -webkit-app-region: drag;
   padding: 10px;
   display: flex;
+  justify-content: center;
 }
 
 #toolbar .column {
@@ -26,12 +27,13 @@
 #toolbar .group_tools {
   margin-top: -10px;
   /* to avoid Mac top-left controls (close/minimize/zoom) */
-  padding-left: 50px;
+  margin-left: 50px;
+  margin-right: 50px;
 }
 body.with-script-visible #toolbar .group_tools,
 body.with-scenes-visible #toolbar .group_tools {
   /* if script OR scenes visible, don't bother */
-  padding-left: 0;
+  margin-left: 0;
 }
 
 #toolbar .button { /* */ }
@@ -145,6 +147,14 @@ body.with-scenes-visible #toolbar .group_tools {
 
 #toolbar .toolbar-colors {
   display: flex;
+  margin-top: 10px;
+  margin-left: 10px;
+  margin-right: 10px;
+}
+@media only screen and (max-width: 1709px) {
+  #toolbar .toolbar-colors {
+    margin-top: 0;
+  }
 }
 
 #toolbar .toolbar-colors_column {

--- a/src/js/window/toolbar.js
+++ b/src/js/window/toolbar.js
@@ -16,7 +16,7 @@ class Toolbar extends EventEmitter {
     this.state = {}
     this.el = el
     this.setState({
-      brush: 'light-pencil',
+      brush: 'pencil',
       transformMode: null,
       captions: true,
 


### PR DESCRIPTION
- center toolbar
- drop palette down to be more vertically aligned with the other buttons
- more breathing room for the palette
- ditch separator lines